### PR TITLE
Remove unused Statistics & Trends section in ToC

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Our survey covers the rapidly evolving field of LLM agents, with a significant i
 ## 📑 Table of Contents
 
 - [🌟 Overview](#-overview)
-- [📊 Statistics & Trends](#-statistics--trends)
 - [🔍 Key Categories](#-key-categories)
 - [📚 Resource List](#-resource-list)
   - [Agent Collaboration](#agent-collaboration)


### PR DESCRIPTION
The `Statistics & Trends` entry in the Table of Contents does not link to any existing heading and does not appear to be a reference to anything in the README