### PR TITLE
Add Implicit Behavioral Alignment of Language Agents (EMNLP 2025)

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,9 @@ language models](https://www.nature.com/articles/s41586-023-06792-0)** (*2023*) 
 - **[CitySim: Modeling Urban Behaviors and City Dynamics with Large-Scale LLM-Driven Agent Simulation](https://arxiv.org/abs/2506.21805)** (*2025*) `Arxiv`
   > The paper presents CitySim, an urban simulator using LLMs. It uses recursive value - driven approach and endows agents with key features, enabling scalable urban studies.
 
+- **[Implicit Behavioral Alignment of Language Agents in High-Stakes Crowd Simulations](https://arxiv.org/abs/2509.16457)** (*2025*) `EMNLP`
+  > Introduces PEBA and PersonaEvolve (PEvo), an LLM-based optimizer that iteratively refines agent personas so crowds of LLM agents behave realistically against expert benchmarks in high-stakes scenarios.
+
 - **[A Survey of AI for Materials Science: Foundation Models, LLM Agents, Datasets, and Tools](https://arxiv.org/abs/2506.20743)** (*2025*) `Arxiv`
   > This paper surveys FMs in MatSci, introducing a taxonomy, discussing advances, reviewing resources, assessing pros & cons, and suggesting future directions.
 


### PR DESCRIPTION

Hi, thanks for keeping this list so well organized, it is a great resource. I would like to suggest adding our EMNLP 2025 (Main) paper to the Applications section. It fits right next to CitySim and the other LLM-driven social simulation entries, since it introduces an LLM-based optimizer (PersonaEvolve) that refines agent personas so crowds of LLM agents match expert behavioral benchmarks. https://arxiv.org/abs/2509.16457

---
Implicit Behavioral Alignment of Language Agents in High-Stakes Crowd Simulations (EMNLP 2025 Main)
arXiv: https://arxiv.org/abs/2509.16457
PDF: https://arxiv.org/pdf/2509.16457