### PR TITLE
Add ClawBench to Datasets & Benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ language models](https://www.nature.com/articles/s41586-023-06792-0)** (*2023*) 
 ### Datasets & Benchmarks
 
 - **[ClawBench: Can AI Agents Complete Everyday Online Tasks?](https://arxiv.org/abs/2604.08523)** (*2026*) `Arxiv`
-  > Introduces ClawBench, 153 write-heavy everyday tasks across 144 live websites, with final-request interception and five-layer trajectories for safe, traceable web-agent evaluation.
+  > Evaluates browser agents on 283 V1+V2 tasks across 163 live websites, with task-scoped submission interception, isolated execution, five-layer traces, and judge-based outcome evaluation.
 
 - **[AgentHarm: Benchmarking Robustness of LLM Agents on Harmful Tasks](https://openreview.net/pdf?id=AC5n7xHuR1)** (*2025*) `ICLR`
   > Proposes AgentHarm, a new benchmark for LLM agents' robustness. Covers 11 harm categories, enabling evaluation of attacks and defenses.
@@ -1204,5 +1204,4 @@ If you find our survey helpful, please consider citing our work:
 <p align="center">
   <i>For questions or suggestions, please open an issue or contact the repository maintainers.</i>
 </p>
-
 

--- a/README.md
+++ b/README.md
@@ -572,6 +572,9 @@ language models](https://www.nature.com/articles/s41586-023-06792-0)** (*2023*) 
 
 ### Datasets & Benchmarks
 
+- **[ClawBench: Can AI Agents Complete Everyday Online Tasks?](https://arxiv.org/abs/2604.08523)** (*2026*) `Arxiv`
+  > Introduces ClawBench, 153 write-heavy everyday tasks across 144 live websites, with final-request interception and five-layer trajectories for safe, traceable web-agent evaluation.
+
 - **[AgentHarm: Benchmarking Robustness of LLM Agents on Harmful Tasks](https://openreview.net/pdf?id=AC5n7xHuR1)** (*2025*) `ICLR`
   > Proposes AgentHarm, a new benchmark for LLM agents' robustness. Covers 11 harm categories, enabling evaluation of attacks and defenses.
 


### PR DESCRIPTION
## Summary

Adds [ClawBench](https://claw-bench.com/) to **Datasets & Benchmarks** in the existing year/venue/summary format.

The paper introduces a browser-agent benchmark with 153 write-heavy everyday tasks across 144 live production websites. Its task-scoped interceptor blocks the annotated terminal request, and each run retains synchronized video, screenshots, HTTP traffic, browser actions, and agent messages for trace-based evaluation.

- Paper: https://arxiv.org/abs/2604.08523
- Code: https://github.com/reacher-z/ClawBench
- Project: https://claw-bench.com/

Checks: full-repository duplicate search and `git diff --check` pass.

Disclosure: I am a ClawBench maintainer submitting our paper for consideration.
