### PR TITLE
Add ClawBench to Datasets & Benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,9 @@ language models](https://www.nature.com/articles/s41586-023-06792-0)** (*2023*) 
 
 ### Datasets & Benchmarks
 
+- **[ClawBench: Can AI Agents Complete Everyday Online Tasks?](https://arxiv.org/abs/2604.08523)** (*2026*) `Arxiv`
+  > Evaluates browser agents on 153 everyday tasks across 144 live websites, with isolated execution and five-layer traces for measuring end-to-end success and agent behavior.
+
 - **[AgentHarm: Benchmarking Robustness of LLM Agents on Harmful Tasks](https://openreview.net/pdf?id=AC5n7xHuR1)** (*2025*) `ICLR`
   > Proposes AgentHarm, a new benchmark for LLM agents' robustness. Covers 11 harm categories, enabling evaluation of attacks and defenses.
 
@@ -1201,5 +1204,4 @@ If you find our survey helpful, please consider citing our work:
 <p align="center">
   <i>For questions or suggestions, please open an issue or contact the repository maintainers.</i>
 </p>
-
 

--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ language models](https://www.nature.com/articles/s41586-023-06792-0)** (*2023*) 
 ### Datasets & Benchmarks
 
 - **[ClawBench: Can AI Agents Complete Everyday Online Tasks?](https://arxiv.org/abs/2604.08523)** (*2026*) `Arxiv`
-  > Evaluates browser agents on 153 everyday tasks across 144 live websites, with isolated execution and five-layer traces for measuring end-to-end success and agent behavior.
+  > Evaluates browser agents on 283 V1+V2 tasks across 163 live websites, with isolated execution, five-layer traces, and submission interception plus judge-based outcome evaluation.
 
 - **[AgentHarm: Benchmarking Robustness of LLM Agents on Harmful Tasks](https://openreview.net/pdf?id=AC5n7xHuR1)** (*2025*) `ICLR`
   > Proposes AgentHarm, a new benchmark for LLM agents' robustness. Covers 11 harm categories, enabling evaluation of attacks and defenses.
@@ -1204,4 +1204,3 @@ If you find our survey helpful, please consider citing our work:
 <p align="center">
   <i>For questions or suggestions, please open an issue or contact the repository maintainers.</i>
 </p>
-


### PR DESCRIPTION
Adds ClawBench to the Datasets & Benchmarks section using the repository’s existing title/year/venue/description format.

ClawBench evaluates browser agents on 153 everyday tasks across 144 live websites, with isolated execution and five-layer traces.

Paper: https://arxiv.org/abs/2604.08523
Code: https://github.com/reacher-z/ClawBench
Project: https://claw-bench.com

Disclosure: I help maintain ClawBench and am submitting this entry in that capacity.